### PR TITLE
Misc. tweakings

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,11 +2,10 @@ using PkgBenchmark
 using Hungarian
 using Munkres
 
-@benchgroup "utf8" ["string", "unicode"] begin
-    RNG = srand(7)
+@benchgroup "square matrix" begin
+    seed = srand(7)
     for n in [10, 50, 100, 200, 400, 800, 1000, 2000]
-        A = rand(RNG, n, n)
-        @bench "Hungarian.jl" hungarian($A)
-        @bench "Munkres.jl" munkres($A)
+        A = rand(seed, n, n)
+        @bench "$n x $n" hungarian($A)
     end
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,5 @@
 using PkgBenchmark
 using Hungarian
-using Munkres
 
 @benchgroup "square matrix" begin
     seed = srand(7)

--- a/benchmark/vsMunkres.jl
+++ b/benchmark/vsMunkres.jl
@@ -1,0 +1,18 @@
+using PkgBenchmark
+using Hungarian
+using Munkres
+
+seed = srand(7)
+@benchgroup "Hungarian" begin
+    for n in [10, 50, 100, 200, 400, 800, 1000, 2000]
+        A = rand(seed, n, n)
+        @bench "$n x $n" hungarian($A)
+    end
+end
+
+@benchgroup "Munkres" begin
+    for n in [10, 50, 100, 200, 400, 800, 1000, 2000]
+        A = rand(seed, n, n)
+        @bench "$n x $n" munkres($A)
+    end
+end

--- a/src/Hungarian.jl
+++ b/src/Hungarian.jl
@@ -40,25 +40,14 @@ julia> assignment, cost = hungarian(A')
 ```
 
 """
-function hungarian{T<:Real}(costMat::Array{T,2})
+function hungarian(costMat::AbstractMatrix)
     r, c = size(costMat)
-    r != c && warn("Currently, the function `hungarian` automatically transposes `cost matrix` when there are more workers than jobs.")
+    # r != c && warn("Currently, the function `hungarian` automatically transposes `cost matrix` when there are more workers than jobs.")
     costMatrix = r ≤ c ? costMat : costMat'
-
-    # run munkres's algorithm
     matching = munkres(costMatrix)
-
-    # find assignment
-    assignment = r ≤ c ? [findfirst(matching[i,:].==STAR) for i = 1:r] : [findfirst(matching[:,i].==STAR) for i = 1:r]
-
+    assignment = r ≤ c ? findn(matching'.==STAR)[1] : [findfirst(matching[:,i].==STAR) for i = 1:r]
     # calculate minimum cost
-    cost = 0
-    for i in zip(1:r, assignment)
-        if i[2] != 0
-            cost += costMat[i...]
-        end
-    end
-
+    cost = sum(costMat[i...] for i in zip(1:r, assignment) if i[2] != 0)
     return assignment, cost
 end
 

--- a/src/Munkres.jl
+++ b/src/Munkres.jl
@@ -144,10 +144,7 @@ end
 """
 Step 2 of the original Munkres' Assignment Algorithm
 """
-function step2!(Zs::SparseMatrixCSC{Int,Int},
-                rowCovered::BitArray{1},
-                columnCovered::BitArray{1}
-               )
+function step2!(Zs, rowCovered, columnCovered)
     ZsDims = size(Zs)
     rows = rowvals(Zs)
     # step 2:
@@ -223,7 +220,7 @@ function step2!(Zs::SparseMatrixCSC{Int,Int},
     end
 
     # "uncover every row"
-    rowCovered[:] = false
+    fill!(rowCovered, false)
 
     # "if all columns are covered, the starred zeros form the desired independent set."
     # here we adjust Munkres's algorithm in order to deal with rectangular matrices,

--- a/src/Munkres.jl
+++ b/src/Munkres.jl
@@ -258,12 +258,6 @@ function step3!(A::Array{T,2}, Zs, rowCovered, columnCovered) where {T<:Real}
         end
     end
 
-    # # "add h to each covered row;"
-    # A[rowCovered,:] += h
-    # # "then subtract h from each uncovered column."
-    # A[:,!columnCovered] -= h
-
-    # de-vectorlize for better performance
     # "add h to each covered row;"
     coveredRowInds = find(rowCovered)
     for j = 1:size(A,2), i in coveredRowInds

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Base.Test
           0.561423  0.170607    0.615941  0.960503  0.981906;
           0.748248  0.00799335  0.554215  0.745299  0.42637]
 
-    assign, cost = hungarian(A)
+    assign, cost = @inferred hungarian(A)
     @test assign == [2, 3, 5, 1, 4]
 
     B = [ 24     1     8;


### PR DESCRIPTION
Speed up a bit when `n` is small:
```
julia> showall(judge("Hungarian", "speedup", "master"))
INFO: Reading results for a6485a from /Users/gnimuc/.julia/v0.6/.benchmarks/Hungarian/results
INFO: Reading results for fcce8c from /Users/gnimuc/.julia/v0.6/.benchmarks/Hungarian/results
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "square matrix" => 8-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "10 x 10" => TrialJudgement(-64.37% => improvement)
	  "100 x 100" => TrialJudgement(-11.60% => improvement)
	  "50 x 50" => TrialJudgement(-30.09% => improvement)
	  "200 x 200" => TrialJudgement(-7.23% => improvement)
	  "1000 x 1000" => TrialJudgement(+2.08% => invariant)
	  "400 x 400" => TrialJudgement(-0.35% => invariant)
	  "800 x 800" => TrialJudgement(+3.13% => invariant)
	  "2000 x 2000" => TrialJudgement(+2.05% => invariant)
```