### PR TITLE
Update parameter type.

### DIFF
--- a/src/Munkres.jl
+++ b/src/Munkres.jl
@@ -26,7 +26,7 @@ julia> full(matching)
  0  0  2
 ```
 """
-function munkres(costMat::Array{T,2}) where {T<:Real}
+function munkres(costMat::AbstractMatrix{T}) where {T<:Real}
     size(costMat,2) ≥ size(costMat,1) || throw(ArgumentError("Non-square matrix should have more columns than rows."))
     A = copy(costMat)
     # preliminaries:
@@ -237,7 +237,7 @@ end
 """
 Step 3 of the original Munkres' Assignment Algorithm
 """
-function step3!(A::Array{T,2}, Zs, rowCovered, columnCovered) where {T<:Real}
+function step3!(A::AbstractMatrix{T}, Zs, rowCovered, columnCovered) where {T<:Real}
     # step 3(Step C):
     # "let h denote the smallest uncovered element of the matrix;"
     # find h and track the location of those new zeros


### PR DESCRIPTION
Change the type of the arguments to be more general: don't need things to be arrays, any kind of matrix will do it (in particular, sparse matrices). Currently, it is not possible to pass sparse matrices as inputs to `munkres`. 