### PR TITLE
Solve #18 by removing rows/columns that cannot be matched

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Hungarian)](https://pkgs.genieframework.com?packages=Hungarian)
 
 
-The package provides one implementation of the **[Hungarian algorithm](https://en.wikipedia.org/wiki/Hungarian_algorithm)**(*Kuhn-Munkres algorithm*) based on its matrix interpretation. This implementation uses a sparse matrix to keep tracking those marked zeros, so it costs less time and memory than [Munkres.jl](https://github.com/FugroRoames/Munkres.jl). Benchmark details can be found [here](https://github.com/Gnimuc/Hungarian.jl/tree/master/benchmark).
+The package provides one implementation of the **[Hungarian algorithm](https://en.wikipedia.org/wiki/Hungarian_algorithm)** (*Kuhn-Munkres algorithm*) based on its matrix interpretation. This implementation uses a sparse matrix to keep tracking those marked zeros, so it costs less time and memory than [Munkres.jl](https://github.com/FugroRoames/Munkres.jl). Benchmark details can be found [here](https://github.com/Gnimuc/Hungarian.jl/tree/master/benchmark).
 
 ## Installation
 ```julia

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![deps](https://juliahub.com/docs/Hungarian/deps.svg)](https://juliahub.com/ui/Packages/Hungarian/effdR?t=2)
 [![Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/Hungarian)](https://pkgs.genieframework.com?packages=Hungarian)
 
-
 The package provides one implementation of the **[Hungarian algorithm](https://en.wikipedia.org/wiki/Hungarian_algorithm)** (*Kuhn-Munkres algorithm*) based on its matrix interpretation. This implementation uses a sparse matrix to keep tracking those marked zeros, so it costs less time and memory than [Munkres.jl](https://github.com/FugroRoames/Munkres.jl). Benchmark details can be found [here](https://github.com/Gnimuc/Hungarian.jl/tree/master/benchmark).
 
 ## Installation
@@ -18,6 +17,7 @@ pkg> add Hungarian
 
 ## Quick start
 Let's say we have 5 workers and 3 tasks with the following cost matrix:
+
 ```julia
 weights = [ 24     1     8;
              5     7    14;
@@ -25,7 +25,9 @@ weights = [ 24     1     8;
             12    19    21;
             18    25     2]
 ```
+
 We can solve the assignment problem by:
+
 ```julia
 julia> using Hungarian
 
@@ -37,10 +39,12 @@ julia> assignment, cost = hungarian(weights)
 # worker 5 => task 3 with weights[5,3] = 2
 # the minimal cost is 1 + 5 + 2 = 8  
 ```
+
 Since each worker can perform only one task and each task can be assigned to only one worker, those `0`s in the `assignment` mean that no task is assigned to those workers.
 
 # Usage
 When solving a canonical assignment problem, namely, the cost matrix is square, one can directly get the matching via `Hungarian.munkres(x)` instead of `hungarian(x)`:
+
 ```julia
 julia> using Hungarian
 
@@ -81,6 +85,9 @@ julia> [findfirst(matching[:,i].==Hungarian.STAR) for i = 1:5]
  3
  4
 ```
+
+> **Note**
+> If some jobs or workers cannot be assigned to any worker or job, respectively, i.e. if some rows or columns only have infinite values (`typemax(T)` where `T` is the type of the elements of the cost matrix), the matrix returned by `Hungarian.munkres` will have zeroes for these rows and columns.
 
 ## References
 1. J. Munkres, "Algorithms for the Assignment and Transportation Problems", Journal of the Society for Industrial and Applied Mathematics, 5(1):32–38, 1957 March.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ julia> [findfirst(matching[:,i].==Hungarian.STAR) for i = 1:5]
  4
 ```
 
+If a job-worker assignment is not possible, use the special `missing` value to indicate which pairs are disallowed:
+
+```julia
+julia> using Hungarian
+
+julia> weights = [missing 1 1; 1 0 1; 1 1 0]
+3×3 Matrix{Union{Missing, Int64}}:
+  missing  1  1
+ 1         0  1
+ 1         1  0
+
+julia> matching = Hungarian.munkres(weights)
+3×3 SparseArrays.SparseMatrixCSC{Int8, Int64} with 6 stored entries:
+ ⋅  2  1
+ 2  1  ⋅
+ 1  ⋅  2
+```
+
 > **Note**
 > If some jobs or workers cannot be assigned to any worker or job, respectively, i.e. if some rows or columns only have infinite values (`typemax(T)` where `T` is the type of the elements of the cost matrix), the matrix returned by `Hungarian.munkres` will have zeroes for these rows and columns.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,22 @@ julia> assignment, cost = hungarian(weights)
 
 Since each worker can perform only one task and each task can be assigned to only one worker, those `0`s in the `assignment` mean that no task is assigned to those workers.
 
-# Usage
+If a job-worker assignment is not possible, use the special `missing` value to indicate which pairs are disallowed:
+
+```julia
+julia> using Hungarian
+
+julia> weights = [missing 1 1; 1 0 1; 1 1 0]
+3×3 Matrix{Union{Missing, Int64}}:
+  missing  1  1
+ 1         0  1
+ 1         1  0
+
+julia> assignment, cost = hungarian(weights)
+([2, 1, 3], 2)
+```
+
+## Usage
 When solving a canonical assignment problem, namely, the cost matrix is square, one can directly get the matching via `Hungarian.munkres(x)` instead of `hungarian(x)`:
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ julia> matching = Hungarian.munkres(weights)
 ```
 
 > **Note**
-> If some jobs or workers cannot be assigned to any worker or job, respectively, i.e. if some rows or columns only have infinite values (`typemax(T)` where `T` is the type of the elements of the cost matrix), the matrix returned by `Hungarian.munkres` will have zeroes for these rows and columns.
+> If some jobs or workers cannot be assigned to any worker or job, respectively, i.e. if some rows or columns only have `missing` or infinite values (`typemax(T)` where `T` is the type of the elements of the cost matrix), the matrix returned by `Hungarian.munkres` will have zeroes for these rows and columns.
 
 ## References
 1. J. Munkres, "Algorithms for the Assignment and Transportation Problems", Journal of the Society for Industrial and Applied Mathematics, 5(1):32–38, 1957 March.

--- a/src/Munkres.jl
+++ b/src/Munkres.jl
@@ -29,8 +29,8 @@ julia> full(matching)
 function munkres(costMat::AbstractMatrix{T}) where {T<:Real}
     # handle a corner case where some rows/columns cannot be matched
     costMatIsMax = costMat .== typemax(T)
-    unmatchableRows = findall(x -> x, vec(all(costMatIsMax, dims=2)))
-    unmatchableCols = findall(x -> x, vec(all(costMatIsMax, dims=1)))
+    unmatchableRows = findall(vec(all(costMatIsMax, dims=2)))
+    unmatchableCols = findall(vec(all(costMatIsMax, dims=1)))
 
     costMat = costMat[1:end .∉ [unmatchableRows], 1:end .∉ [unmatchableCols]]
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,10 @@ end
     assign,cost=hungarian(M)
     @test assign == [3, 5, 4, 2, 1]
     @test cost   == 71139
+@testset "issue #18" begin
+    # These instances used to run into infinite loops.
+    weights_int = [1.0 Inf; Inf Inf]
+    result = Hungarian.munkres(weights_int)
 end
 
 @testset "UInt8" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,14 @@ end
     @test costH ≤ costR
 end
 
+@testset "issue #18" begin
+    # This instance used to run into infinite loops: a row and a column could never be matched.
+    weights = [1.0 Inf; Inf Inf]
+    assign, cost = hungarian(weights)
+    @test assign == [1, 0]
+    @test cost == 1.0
+end
+
 @testset "UInt16" begin
     M=UInt16[28092 44837 19882 39481 59139;
              26039 46258 38932 51057 9;
@@ -65,10 +73,6 @@ end
     assign,cost=hungarian(M)
     @test assign == [3, 5, 4, 2, 1]
     @test cost   == 71139
-@testset "issue #18" begin
-    # These instances used to run into infinite loops.
-    weights_int = [1.0 Inf; Inf Inf]
-    result = Hungarian.munkres(weights_int)
 end
 
 @testset "UInt8" begin


### PR DESCRIPTION
The patch works in two parts: first, determine which rows and columns cannot be matched (I did that as efficiently as possible, I think); then, if needed, add back the rows and columns. 

The matrix returned by `munkres` is changed, with only zero values instead of whatever it computes in the integer case. However, `hungarian` gets the right output. All the tests pass.