### PR TITLE
add aarch64 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
         exclude:
           - os: macOS-latest
             arch: x86
+        include:
+          - arch: aarch64
+            os: macos-latest
+            version: '1'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
GraphsMatching.jl is failing on Mac aarch64, so I was hoping we can add this check here as a way to exclude Hungarian.jl as the root cause.